### PR TITLE
WebsocketCppService: refactor on connection open task

### DIFF
--- a/WebsocketCppService/WsServerPlain.cpp
+++ b/WebsocketCppService/WsServerPlain.cpp
@@ -30,7 +30,7 @@ namespace shape {
   {
   };
 
-  
+
   WsServerPlain::WsServerPlain()
   {
     m_imp = shape_new WsServerPlain::Imp();
@@ -75,15 +75,15 @@ namespace shape {
   {
     m_imp->stop_listening();
   }
-  
+
   void WsServerPlain::getConnParams(connection_hdl chdl, std::string & connId, websocketpp::uri_ptr & uri)
   {
     m_imp->getConnParams(chdl, connId, uri);
   }
 
-  void WsServerPlain::setOnFunctions(OnValidate onValidate, OnFail onFail, OnClose onClose, OnMessage onMessage)
+  void WsServerPlain::setOnFunctions(OnValidate onValidate, OnOpen onOpen, OnFail onFail, OnClose onClose, OnMessage onMessage)
   {
-    m_imp->setOnFunctions(onValidate, onFail, onClose, onMessage);
+    m_imp->setOnFunctions(onValidate, onOpen, onFail, onClose, onMessage);
   }
 
 }

--- a/WebsocketCppService/WsServerPlain.h
+++ b/WebsocketCppService/WsServerPlain.h
@@ -33,7 +33,7 @@ namespace shape {
     void close(connection_hdl chndl, const std::string & descr, const std::string & data) override;
     void stop_listening() override;
     void getConnParams(connection_hdl chdl, std::string & connId, websocketpp::uri_ptr & uri) override;
-    void setOnFunctions(OnValidate onValidate, OnFail onFail, OnClose onClose, OnMessage onMessage) override;
+    void setOnFunctions(OnValidate onValidate, OnOpen onOpen, OnFail onFail, OnClose onClose, OnMessage onMessage) override;
 
   private:
     class Imp;

--- a/WebsocketCppService/WsServerTls.cpp
+++ b/WebsocketCppService/WsServerTls.cpp
@@ -184,9 +184,9 @@ namespace shape {
     m_imp->getConnParams(chdl, connId, uri);
   }
 
-  void WsServerTls::setOnFunctions(OnValidate onValidate, OnFail onFail, OnClose onClose, OnMessage onMessage)
+  void WsServerTls::setOnFunctions(OnValidate onValidate, OnOpen onOpen, OnFail onFail, OnClose onClose, OnMessage onMessage)
   {
-    m_imp->setOnFunctions(onValidate, onFail, onClose, onMessage);
+    m_imp->setOnFunctions(onValidate, onOpen, onFail, onClose, onMessage);
   }
 
   void WsServerTls::setTls(const std::string &modeStr, const std::string & cert, const std::string & key)

--- a/WebsocketCppService/WsServerTls.h
+++ b/WebsocketCppService/WsServerTls.h
@@ -33,7 +33,7 @@ namespace shape {
     void close(connection_hdl chndl, const std::string & descr, const std::string & data) override;
     void stop_listening() override;
     void getConnParams(connection_hdl chdl, std::string & connId, websocketpp::uri_ptr & uri) override;
-    void setOnFunctions(OnValidate onValidate, OnFail onFail, OnClose onClose, OnMessage onMessage) override;
+    void setOnFunctions(OnValidate onValidate, OnOpen onOpen, OnFail onFail, OnClose onClose, OnMessage onMessage) override;
     void setTls(const std::string &mode, const std::string & cert, const std::string & key);
 
   private:


### PR DESCRIPTION
onOpen callbacks cannot be called during validation step as the connection has not yet been fully established.

Websocketpp on_validate notes:

> This hook is triggered for servers during the opening handshake after the request has been processed but before the response has been sent. It gives a program the opportunity to inspect headers and other connection details and either accept or reject the connection. Validate happens before the open or fail handler.
> 
> Return true to accept the connection, false to reject. If no validate handler is registered, all connections will be accepted.

Signed-off-by: Karel Hanák <karel.hanak@iqrf.org>